### PR TITLE
Ignore hidden files/dirs as test cases.

### DIFF
--- a/src/xmlsec/test/case.py
+++ b/src/xmlsec/test/case.py
@@ -39,6 +39,7 @@ def load_test_data(path=None):
         return  # fool unittest that executes this function
     cases = {}
     for case_n in pkg_resources.resource_listdir(__name__, path):
-        case = XMLTestData(__name__, os.path.join(path, case_n))
-        cases[case_n] = case
+        if case_n[0] != '.': # ignore hidden files/directories
+            case = XMLTestData(__name__, os.path.join(path, case_n))
+            cases[case_n] = case
     return cases


### PR DESCRIPTION
Mac OS X has a habit of dropping `.DS_Store` files into directories you look at. This prevents those being used as test cases, which fails because they are not directories.
