### PR TITLE
Quick, hacky fix for #47 "Private Key might leak"

### DIFF
--- a/src/xmlsec/crypto.py
+++ b/src/xmlsec/crypto.py
@@ -130,11 +130,13 @@ class XMLSecCryptoFile(XMlSecCrypto):
                 if not isinstance(self.key, rsa.RSAPrivateKey):
                     raise XMLSigException("We don't support non-RSA private keys at the moment.")
 
-                # XXX now we could implement encrypted-PEM-support
-                self.cert_pem = self.key.private_bytes(
-                    encoding=serialization.Encoding.PEM,
-                    format=serialization.PrivateFormat.PKCS8,
-                    encryption_algorithm=serialization.NoEncryption())
+                # XXX Do not leak private key -- is there any situation
+                # where we might need this pem?
+                self.cert_pem = None
+                # self.cert_pem = self.key.private_bytes(
+                #     encoding=serialization.Encoding.PEM,
+                #     format=serialization.PrivateFormat.PKCS8,
+                #     encryption_algorithm=serialization.NoEncryption())
 
                 self.keysize = self.key.key_size
             else:


### PR DESCRIPTION
Quick, hacky fix for #47 "Private Key might leak".

I restored the old crypt-lib behaviour which
never exported the private key but set cert_pem=None.

'Right' solution might be a better differentiation of private,
public key and certs inside the XMlSecCrypto-Class.


